### PR TITLE
Modal dialog text alignment

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -14,7 +14,7 @@
 
 	.modal-dialog {
 	  display: inline-block;
-	  text-align: right;
+	  text-align: left;
 	  vertical-align: middle;
 	}
 


### PR DESCRIPTION
Modal text initial alignment set to left as this is the norm. Let themers and RTL users change this via their implementation.
